### PR TITLE
Add App Component Tests, and Simplify Page Test Util Method

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,70 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, TestBed } from '@angular/core/testing';
+import { IonicModule, Platform } from 'ionic-angular';
+
+import { SplashScreen } from '@ionic-native/splash-screen';
+import { StatusBar } from '@ionic-native/status-bar';
+
+import { CopayApp } from './app.component';
+
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import {
+  TranslateFakeLoader,
+  TranslateLoader,
+  TranslateModule
+} from '@ngx-translate/core';
+import { EmailNotificationsProvider } from '../providers/email-notifications/email-notifications';
+import { ProfileProvider } from '../providers/profile/profile';
+import { ProvidersModule } from './../providers/providers.module';
+
+describe('CopayApp', () => {
+  let fixture;
+  let component;
+
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        declarations: [CopayApp],
+        schemas: [NO_ERRORS_SCHEMA],
+        imports: [
+          IonicModule.forRoot(CopayApp),
+          ProvidersModule,
+          HttpClientTestingModule,
+          TranslateModule.forRoot({
+            loader: { provide: TranslateLoader, useClass: TranslateFakeLoader }
+          })
+        ]
+      });
+    })
+  );
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(CopayApp);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component instanceof CopayApp).toBe(true);
+  });
+
+  describe('Methods', () => {
+    describe('onProfileLoad', () => {
+      let emailNotificationsProvider;
+      beforeEach(() => {
+        emailNotificationsProvider = TestBed.get(EmailNotificationsProvider);
+        spyOn(emailNotificationsProvider, 'init');
+      });
+      it('should init email notifications', () => {
+        component.onProfileLoad({});
+        expect(emailNotificationsProvider.init).toHaveBeenCalled();
+      });
+      it('should create a new profile if none returned', () => {
+        const profileProvider = TestBed.get(ProfileProvider);
+        spyOn(profileProvider, 'createProfile');
+        component.onProfileLoad();
+        expect(profileProvider.createProfile).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,13 @@ import { Component, ViewChild } from '@angular/core';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { SplashScreen } from '@ionic-native/splash-screen';
 import { StatusBar } from '@ionic-native/status-bar';
-import { App, Events, ModalController, NavController, Platform } from 'ionic-angular';
+import {
+  App,
+  Events,
+  ModalController,
+  NavController,
+  Platform
+} from 'ionic-angular';
 import { Subscription } from 'rxjs';
 
 // providers
@@ -39,8 +45,8 @@ import { AddressbookAddPage } from '../pages/settings/addressbook/add/add';
 import { TabsPage } from '../pages/tabs/tabs';
 import { WalletDetailsPage } from '../pages/wallet-details/wallet-details';
 
-// As the handleOpenURL handler kicks in before the App is started, 
-// declare the handler function at the top of app.component.ts (outside the class definition) 
+// As the handleOpenURL handler kicks in before the App is started,
+// declare the handler function at the top of app.component.ts (outside the class definition)
 // to track the passed Url
 (window as any).handleOpenURL = (url: string) => {
   (window as any).handleOpenURL_LastURL = url;
@@ -51,12 +57,25 @@ import { WalletDetailsPage } from '../pages/wallet-details/wallet-details';
   providers: [TouchIdProvider]
 })
 export class CopayApp {
-
   @ViewChild('appNav') nav: NavController;
 
   public rootPage: any;
   private onResumeSubscription: Subscription;
   private isModalOpen: boolean;
+
+  private pageMap: { [name: string]: any } = {
+    AddressbookAddPage,
+    AmountPage,
+    BitPayCardIntroPage,
+    CoinbasePage,
+    ConfirmPage,
+    CopayersPage,
+    GlideraPage,
+    ImportWalletPage,
+    JoinWalletPage,
+    PaperWalletPage,
+    WalletDetailsPage
+  };
 
   constructor(
     private platform: Platform,
@@ -83,78 +102,106 @@ export class CopayApp {
     this.initializeApp();
   }
 
+  ngOnDestroy() {
+    this.onResumeSubscription.unsubscribe();
+  }
+
   initializeApp() {
-    this.platform.ready().then((readySource) => {
-      this.appProvider.load().then(() => {
-        this.logger.info(
-          'Platform ready (' + readySource + '): ' +
-          this.appProvider.info.nameCase +
-          ' - v' + this.appProvider.info.version +
-          ' #' + this.appProvider.info.commitHash);
+    this.platform
+      .ready()
+      .then(readySource => {
+        this.onPlatformReady(readySource);
+      })
+      .catch(e => {
+        this.logger.error('Platform is not ready.', e);
+      });
+  }
 
-        if (this.platform.is('cordova')) {
-          this.statusBar.show();
-
-          // Set to portrait
-          this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT);
-
-          // Only overlay for iOS
-          if (this.platform.is('ios')) this.statusBar.overlaysWebView(true);
-
-          this.statusBar.styleLightContent();
-          this.splashScreen.hide();
-
-          // Subscribe Resume
-          this.onResumeSubscription = this.platform.resume.subscribe(() => {
-
-            // Update Wallet Status
-            this.events.publish('status:updated');
-
-            // Check PIN or Fingerprint
-            this.openLockModal();
-          });
-
-        }
-        this.openLockModal();
-        this.registerIntegrations();
-        this.incomingDataRedirEvent();
-        // Check Profile
-        this.profile.loadAndBindProfile().then((profile: any) => {
-          this.emailNotificationsProvider.init(); // Update email subscription if necessary
-          this.initPushNotifications();
-
-          if (profile) {
-            this.logger.info('Profile exists.');
-            this.rootPage = TabsPage;
-          }
-          else {
-            this.logger.info('No profile exists.');
-            this.profile.createProfile();
-            this.rootPage = OnboardingPage;
-          }
-        }).catch((err: Error) => {
-          this.logger.warn('LoadAndBindProfile', err.message);
-          this.rootPage = err.message == 'ONBOARDINGNONCOMPLETED: Onboarding non completed' ? OnboardingPage : DisclaimerPage;
-        });
-      }).catch((err) => {
+  private onPlatformReady(readySource): void {
+    this.appProvider
+      .load()
+      .then(() => {
+        this.onAppLoad(readySource);
+      })
+      .catch(err => {
         let title = 'Could not initialize the app';
         let message = JSON.stringify(err);
         this.popupProvider.ionicAlert(title, message);
       });
-
-    }).catch((e) => {
-      this.logger.error('Platform is not ready.', e);
-    });
   }
 
-  ngOnDestroy() {
-    this.onResumeSubscription.unsubscribe();
+  private onAppLoad(readySource) {
+    this.logger.info(
+      'Platform ready (' +
+        readySource +
+        '): ' +
+        this.appProvider.info.nameCase +
+        ' - v' +
+        this.appProvider.info.version +
+        ' #' +
+        this.appProvider.info.commitHash
+    );
+
+    if (this.platform.is('cordova')) {
+      this.statusBar.show();
+
+      // Set to portrait
+      this.screenOrientation.lock(this.screenOrientation.ORIENTATIONS.PORTRAIT);
+
+      // Only overlay for iOS
+      if (this.platform.is('ios')) this.statusBar.overlaysWebView(true);
+
+      this.statusBar.styleLightContent();
+      this.splashScreen.hide();
+
+      // Subscribe Resume
+      this.onResumeSubscription = this.platform.resume.subscribe(() => {
+        // Update Wallet Status
+        this.events.publish('status:updated');
+
+        // Check PIN or Fingerprint
+        this.openLockModal();
+      });
+    }
+    this.openLockModal();
+    this.registerIntegrations();
+    this.incomingDataRedirEvent();
+    // Check Profile
+    this.profile
+      .loadAndBindProfile()
+      .then((profile: any) => {
+        this.onProfileLoad(profile);
+      })
+      .catch((err: Error) => {
+        this.logger.warn('LoadAndBindProfile', err.message);
+        this.rootPage =
+          err.message == 'ONBOARDINGNONCOMPLETED: Onboarding non completed'
+            ? OnboardingPage
+            : DisclaimerPage;
+      });
+  }
+
+  private onProfileLoad(profile) {
+    this.emailNotificationsProvider.init(); // Update email subscription if necessary
+    this.initPushNotifications();
+
+    if (profile) {
+      this.logger.info('Profile exists.');
+      this.rootPage = TabsPage;
+    } else {
+      this.logger.info('No profile exists.');
+      this.profile.createProfile();
+      this.rootPage = OnboardingPage;
+    }
   }
 
   private openLockModal(): void {
     if (this.isModalOpen) return;
     let config: any = this.configProvider.get();
-    let lockMethod = (config && config.lock && config.lock.method) ? config.lock.method.toLowerCase() : null;
+    let lockMethod =
+      config && config.lock && config.lock.method
+        ? config.lock.method.toLowerCase()
+        : null;
     if (!lockMethod) return;
     if (lockMethod == 'pin') this.openPINModal('checkPin');
     if (lockMethod == 'fingerprint') this.openFingerprintModal();
@@ -180,15 +227,17 @@ export class CopayApp {
   }
 
   private registerIntegrations(): void {
-
     // Mercado Libre
-    if (this.appProvider.info._enabledExtensions.mercadolibre) this.mercadoLibreProvider.register();
+    if (this.appProvider.info._enabledExtensions.mercadolibre)
+      this.mercadoLibreProvider.register();
 
     // Amazon Gift Cards
-    if (this.appProvider.info._enabledExtensions.amazon) this.amazonProvider.register();
+    if (this.appProvider.info._enabledExtensions.amazon)
+      this.amazonProvider.register();
 
     // ShapeShift
-    if (this.appProvider.info._enabledExtensions.shapeshift) this.shapeshiftProvider.register();
+    if (this.appProvider.info._enabledExtensions.shapeshift)
+      this.shapeshiftProvider.register();
 
     // Glidera
     if (this.appProvider.info._enabledExtensions.glidera) {
@@ -203,34 +252,20 @@ export class CopayApp {
     }
 
     // BitPay Card
-    if (this.appProvider.info._enabledExtensions.debitcard) this.bitPayCardProvider.register();
+    if (this.appProvider.info._enabledExtensions.debitcard)
+      this.bitPayCardProvider.register();
   }
 
   private incomingDataRedirEvent(): void {
-    this.events.subscribe('IncomingDataRedir', (nextView) => {
-      const pageMap = {
-        ImportWalletPage,
-        JoinWalletPage,
-        BitPayCardIntroPage,
-        CoinbasePage,
-        GlideraPage,
-        AmountPage,
-        ConfirmPage,
-        PaperWalletPage,
-        AddressbookAddPage
-      };
-      this.nav.push(pageMap[nextView.name], nextView.params);
+    this.events.subscribe('IncomingDataRedir', nextView => {
+      this.nav.push(this.pageMap[nextView.name], nextView.params);
     });
   }
 
   private initPushNotifications() {
-    this.events.subscribe('OpenWalletEvent', (nextView) => {
+    this.events.subscribe('OpenWalletEvent', nextView => {
       this.app.getRootNavs()[0].setRoot(TabsPage);
-      const pageMap = {
-        CopayersPage,
-        WalletDetailsPage
-      };
-      this.nav.push(pageMap[nextView.name], nextView.params);
+      this.nav.push(this.pageMap[nextView.name], nextView.params);
     });
     this.pushNotificationsProvider.init();
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,21 +2,7 @@ import { DecimalPipe } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { File } from '@ionic-native/file';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
-
-/* Native modules */
-import { AndroidFingerprintAuth } from '@ionic-native/android-fingerprint-auth';
-import { Clipboard } from '@ionic-native/clipboard';
-import { Device } from '@ionic-native/device';
-import { FCM } from '@ionic-native/fcm';
-import { QRScanner } from '@ionic-native/qr-scanner';
-import { ScreenOrientation } from '@ionic-native/screen-orientation';
-import { SocialSharing } from '@ionic-native/social-sharing';
-import { SplashScreen } from '@ionic-native/splash-screen';
-import { StatusBar } from '@ionic-native/status-bar';
-import { Toast } from '@ionic-native/toast';
-import { TouchID } from '@ionic-native/touch-id';
 
 /* Modules */
 import { TranslatePoHttpLoader } from '@biesbjerg/ngx-translate-po-http-loader';
@@ -166,50 +152,6 @@ import { OrderByPipe } from '../pipes/order-by';
 import { SatToFiatPipe } from '../pipes/satToFiat';
 import { SatToUnitPipe } from '../pipes/satToUnit';
 
-/* Providers */
-import { AddressBookProvider } from '../providers/address-book/address-book';
-import { AddressProvider } from '../providers/address/address';
-import { AmazonProvider } from '../providers/amazon/amazon';
-import { AppIdentityProvider } from '../providers/app-identity/app-identity';
-import { AppProvider } from '../providers/app/app';
-import { BackupProvider } from '../providers/backup/backup';
-import { BitPayAccountProvider } from '../providers/bitpay-account/bitpay-account';
-import { BitPayCardProvider } from '../providers/bitpay-card/bitpay-card';
-import { BitPayProvider } from '../providers/bitpay/bitpay';
-import { BwcErrorProvider } from '../providers/bwc-error/bwc-error';
-import { BwcProvider } from '../providers/bwc/bwc';
-import { CoinbaseProvider } from '../providers/coinbase/coinbase';
-import { ConfigProvider } from '../providers/config/config';
-import { DerivationPathHelperProvider } from '../providers/derivation-path-helper/derivation-path-helper';
-import { EmailNotificationsProvider } from '../providers/email-notifications/email-notifications';
-import { ExternalLinkProvider } from '../providers/external-link/external-link';
-import { FeeProvider } from '../providers/fee/fee';
-import { FeedbackProvider } from '../providers/feedback/feedback';
-import { FilterProvider } from '../providers/filter/filter';
-import { GlideraProvider } from '../providers/glidera/glidera';
-import { HomeIntegrationsProvider } from '../providers/home-integrations/home-integrations';
-import { IncomingDataProvider } from '../providers/incoming-data/incoming-data';
-import { LanguageProvider } from '../providers/language/language';
-import { Logger } from '../providers/logger/logger';
-import { MercadoLibreProvider } from '../providers/mercado-libre/mercado-libre';
-import { NodeWebkitProvider } from '../providers/node-webkit/node-webkit';
-import { OnGoingProcessProvider } from '../providers/on-going-process/on-going-process';
-import { PayproProvider } from '../providers/paypro/paypro';
-import { PersistenceProvider } from '../providers/persistence/persistence';
-import { PlatformProvider } from '../providers/platform/platform';
-import { PopupProvider } from '../providers/popup/popup';
-import { ProfileProvider } from '../providers/profile/profile';
-import { PushNotificationsProvider } from '../providers/push-notifications/push-notifications';
-import { RateProvider } from '../providers/rate/rate';
-import { ReleaseProvider } from '../providers/release/release';
-import { ScanProvider } from '../providers/scan/scan';
-import { ShapeshiftProvider } from '../providers/shapeshift/shapeshift';
-import { TimeProvider } from '../providers/time/time';
-import { TouchIdProvider } from '../providers/touchid/touchid';
-import { TxConfirmNotificationProvider } from '../providers/tx-confirm-notification/tx-confirm-notification';
-import { TxFormatProvider } from '../providers/tx-format/tx-format';
-import { WalletProvider } from '../providers/wallet/wallet';
-
 /* Directives */
 import { CopyToClipboard } from '../directives/copy-to-clipboard/copy-to-clipboard';
 import { IosScrollBgColor } from '../directives/ios-scroll-bg-color/ios-scroll-bg-color';
@@ -219,6 +161,9 @@ import { NoLowFee } from '../directives/no-low-fee/no-low-fee';
 
 /* Components */
 import { ComponentsModule } from './../components/components.module';
+
+/* Providers */
+import { ProvidersModule } from './../providers/providers.module';
 
 /* Read translation files */
 export function createTranslateLoader(http: HttpClient) {
@@ -355,6 +300,7 @@ export function createTranslateLoader(http: HttpClient) {
     HttpClientModule,
     MomentModule,
     NgxQRCodeModule,
+    ProvidersModule,
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
@@ -471,61 +417,6 @@ export function createTranslateLoader(http: HttpClient) {
     SlideToAcceptPage
   ],
   providers: [
-    AddressProvider,
-    AddressBookProvider,
-    AndroidFingerprintAuth,
-    AppProvider,
-    AppIdentityProvider,
-    AmazonProvider,
-    BackupProvider,
-    BitPayProvider,
-    BitPayCardProvider,
-    BitPayAccountProvider,
-    BwcProvider,
-    BwcErrorProvider,
-    ConfigProvider,
-    CoinbaseProvider,
-    Clipboard,
-    DerivationPathHelperProvider,
-    Device,
-    ExternalLinkProvider,
-    FeedbackProvider,
-    FCM,
-    HomeIntegrationsProvider,
-    FeeProvider,
-    GlideraProvider,
-    IncomingDataProvider,
-    LanguageProvider,
-    Logger,
-    MercadoLibreProvider,
-    NodeWebkitProvider,
-    OnGoingProcessProvider,
-    PayproProvider,
-    PlatformProvider,
-    ProfileProvider,
-    PopupProvider,
-    QRScanner,
-    PushNotificationsProvider,
-    RateProvider,
-    ReleaseProvider,
-    ShapeshiftProvider,
-    StatusBar,
-    SplashScreen,
-    ScanProvider,
-    ScreenOrientation,
-    SocialSharing,
-    Toast,
-    TouchID,
-    TimeProvider,
-    TouchIdProvider,
-    TxConfirmNotificationProvider,
-    FilterProvider,
-    TxFormatProvider,
-    WalletProvider,
-    EmailNotificationsProvider,
-    DecimalPipe,
-    PersistenceProvider,
-    File,
     {
       provide: ErrorHandler,
       useClass: IonicErrorHandler

--- a/src/pages/home/home.spec.ts
+++ b/src/pages/home/home.spec.ts
@@ -13,35 +13,7 @@ import { TestUtils } from '../../test';
 import { HomePage } from './home';
 
 import { AddressBookProvider } from '../../providers/address-book/address-book';
-import { AppIdentityProvider } from '../../providers/app-identity/app-identity';
-import { AppProvider } from '../../providers/app/app';
-import { BitPayCardProvider } from '../../providers/bitpay-card/bitpay-card';
-import { BitPayProvider } from '../../providers/bitpay/bitpay';
-import { ExternalLinkProvider } from '../../providers/external-link/external-link';
-import { FeeProvider } from '../../providers/fee/fee';
-import { FeedbackProvider } from '../../providers/feedback/feedback';
-import { FilterProvider } from '../../providers/filter/filter';
-import { HomeIntegrationsProvider } from '../../providers/home-integrations/home-integrations';
-import { IncomingDataProvider } from '../../providers/incoming-data/incoming-data';
-import { LanguageProvider } from '../../providers/language/language';
-import { NodeWebkitProvider } from '../../providers/node-webkit/node-webkit';
-import { OnGoingProcessProvider } from '../../providers/on-going-process/on-going-process';
-import { PayproProvider } from '../../providers/paypro/paypro';
-import { PlatformProvider } from '../../providers/platform/platform';
-import { PopupProvider } from '../../providers/popup/popup';
-import { PushNotificationsProvider } from '../../providers/push-notifications/push-notifications';
-import { RateProvider } from '../../providers/rate/rate';
-import { ReleaseProvider } from '../../providers/release/release';
-import { ScanProvider } from '../../providers/scan/scan';
-import { TouchIdProvider } from '../../providers/touchid/touchid';
-import { TxFormatProvider } from '../../providers/tx-format/tx-format';
-import { WalletProvider } from '../../providers/wallet/wallet';
-import { BwcErrorProvider } from './../../providers/bwc-error/bwc-error';
-import { BwcProvider } from './../../providers/bwc/bwc';
 import { ConfigProvider } from './../../providers/config/config';
-import { Logger } from './../../providers/logger/logger';
-import { PersistenceProvider } from './../../providers/persistence/persistence';
-import { ProfileProvider } from './../../providers/profile/profile';
 
 describe('HomePage', () => {
   let fixture: ComponentFixture<HomePage>;
@@ -50,38 +22,7 @@ describe('HomePage', () => {
 
   beforeEach(
     async(() =>
-      TestUtils.configurePageTestingModule([HomePage], {
-        providers: [
-          AddressBookProvider,
-          AppIdentityProvider,
-          BitPayCardProvider,
-          BitPayProvider,
-          BwcProvider,
-          BwcErrorProvider,
-          ConfigProvider,
-          ExternalLinkProvider,
-          FeedbackProvider,
-          FeeProvider,
-          FilterProvider,
-          HomeIntegrationsProvider,
-          IncomingDataProvider,
-          LanguageProvider,
-          Logger,
-          NodeWebkitProvider,
-          OnGoingProcessProvider,
-          PayproProvider,
-          PersistenceProvider,
-          PopupProvider,
-          ProfileProvider,
-          PushNotificationsProvider,
-          RateProvider,
-          ReleaseProvider,
-          ScanProvider,
-          TouchIdProvider,
-          TxFormatProvider,
-          WalletProvider
-        ]
-      }).then(testEnv => {
+      TestUtils.configurePageTestingModule([HomePage]).then(testEnv => {
         fixture = testEnv.fixture;
         instance = testEnv.instance;
         testBed = testEnv.testBed;

--- a/src/providers/providers.module.ts
+++ b/src/providers/providers.module.ts
@@ -1,0 +1,129 @@
+import { NgModule } from '@angular/core';
+
+import { DecimalPipe } from '@angular/common';
+
+/* Native modules */
+import { AndroidFingerprintAuth } from '@ionic-native/android-fingerprint-auth';
+import { Clipboard } from '@ionic-native/clipboard';
+import { Device } from '@ionic-native/device';
+import { FCM } from '@ionic-native/fcm';
+import { File } from '@ionic-native/file';
+import { QRScanner } from '@ionic-native/qr-scanner';
+import { ScreenOrientation } from '@ionic-native/screen-orientation';
+import { SocialSharing } from '@ionic-native/social-sharing';
+import { SplashScreen } from '@ionic-native/splash-screen';
+import { StatusBar } from '@ionic-native/status-bar';
+import { Toast } from '@ionic-native/toast';
+import { TouchID } from '@ionic-native/touch-id';
+
+/* Pipes */
+import { FiatToUnitPipe } from '../pipes/fiatToUnit';
+import { KeysPipe } from '../pipes/keys';
+import { OrderByPipe } from '../pipes/order-by';
+import { SatToFiatPipe } from '../pipes/satToFiat';
+import { SatToUnitPipe } from '../pipes/satToUnit';
+
+/* Providers */
+import { AddressBookProvider } from '../providers/address-book/address-book';
+import { AddressProvider } from '../providers/address/address';
+import { AmazonProvider } from '../providers/amazon/amazon';
+import { AppIdentityProvider } from '../providers/app-identity/app-identity';
+import { AppProvider } from '../providers/app/app';
+import { BackupProvider } from '../providers/backup/backup';
+import { BitPayAccountProvider } from '../providers/bitpay-account/bitpay-account';
+import { BitPayCardProvider } from '../providers/bitpay-card/bitpay-card';
+import { BitPayProvider } from '../providers/bitpay/bitpay';
+import { BwcErrorProvider } from '../providers/bwc-error/bwc-error';
+import { BwcProvider } from '../providers/bwc/bwc';
+import { CoinbaseProvider } from '../providers/coinbase/coinbase';
+import { ConfigProvider } from '../providers/config/config';
+import { DerivationPathHelperProvider } from '../providers/derivation-path-helper/derivation-path-helper';
+import { EmailNotificationsProvider } from '../providers/email-notifications/email-notifications';
+import { ExternalLinkProvider } from '../providers/external-link/external-link';
+import { FeeProvider } from '../providers/fee/fee';
+import { FeedbackProvider } from '../providers/feedback/feedback';
+import { FilterProvider } from '../providers/filter/filter';
+import { GlideraProvider } from '../providers/glidera/glidera';
+import { HomeIntegrationsProvider } from '../providers/home-integrations/home-integrations';
+import { IncomingDataProvider } from '../providers/incoming-data/incoming-data';
+import { LanguageProvider } from '../providers/language/language';
+import { Logger } from '../providers/logger/logger';
+import { MercadoLibreProvider } from '../providers/mercado-libre/mercado-libre';
+import { NodeWebkitProvider } from '../providers/node-webkit/node-webkit';
+import { OnGoingProcessProvider } from '../providers/on-going-process/on-going-process';
+import { PayproProvider } from '../providers/paypro/paypro';
+import { PersistenceProvider } from '../providers/persistence/persistence';
+import { PlatformProvider } from '../providers/platform/platform';
+import { PopupProvider } from '../providers/popup/popup';
+import { ProfileProvider } from '../providers/profile/profile';
+import { PushNotificationsProvider } from '../providers/push-notifications/push-notifications';
+import { RateProvider } from '../providers/rate/rate';
+import { ReleaseProvider } from '../providers/release/release';
+import { ScanProvider } from '../providers/scan/scan';
+import { ShapeshiftProvider } from '../providers/shapeshift/shapeshift';
+import { TimeProvider } from '../providers/time/time';
+import { TouchIdProvider } from '../providers/touchid/touchid';
+import { TxConfirmNotificationProvider } from '../providers/tx-confirm-notification/tx-confirm-notification';
+import { TxFormatProvider } from '../providers/tx-format/tx-format';
+import { WalletProvider } from '../providers/wallet/wallet';
+
+@NgModule({
+  providers: [
+    AddressProvider,
+    AddressBookProvider,
+    AndroidFingerprintAuth,
+    AppProvider,
+    AppIdentityProvider,
+    AmazonProvider,
+    BackupProvider,
+    BitPayProvider,
+    BitPayCardProvider,
+    BitPayAccountProvider,
+    BwcProvider,
+    BwcErrorProvider,
+    ConfigProvider,
+    CoinbaseProvider,
+    Clipboard,
+    DerivationPathHelperProvider,
+    Device,
+    ExternalLinkProvider,
+    FeedbackProvider,
+    FCM,
+    HomeIntegrationsProvider,
+    FeeProvider,
+    GlideraProvider,
+    IncomingDataProvider,
+    LanguageProvider,
+    Logger,
+    MercadoLibreProvider,
+    NodeWebkitProvider,
+    OnGoingProcessProvider,
+    PayproProvider,
+    PlatformProvider,
+    ProfileProvider,
+    PopupProvider,
+    QRScanner,
+    PushNotificationsProvider,
+    RateProvider,
+    ReleaseProvider,
+    ShapeshiftProvider,
+    StatusBar,
+    SplashScreen,
+    ScanProvider,
+    ScreenOrientation,
+    SocialSharing,
+    Toast,
+    TouchID,
+    TimeProvider,
+    TouchIdProvider,
+    TxConfirmNotificationProvider,
+    FilterProvider,
+    TxFormatProvider,
+    WalletProvider,
+    EmailNotificationsProvider,
+    DecimalPipe,
+    PersistenceProvider,
+    File
+  ]
+})
+export class ProvidersModule {}

--- a/src/test.ts
+++ b/src/test.ts
@@ -62,12 +62,15 @@ import { AndroidFingerprintAuth } from '@ionic-native/android-fingerprint-auth';
 import { FCM } from '@ionic-native/fcm';
 import { File } from '@ionic-native/file';
 import { QRScanner } from '@ionic-native/qr-scanner';
+
 import { TouchID } from '@ionic-native/touch-id';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { AppProvider } from './providers/app/app';
 import { PersistenceProvider } from './providers/persistence/persistence';
 import { PlatformProvider } from './providers/platform/platform';
+
+import { ProvidersModule } from './providers/providers.module';
 
 import * as appTemplate from './../app-template/bitpay/appConfig.json';
 
@@ -118,7 +121,7 @@ export class TestUtils {
 
   public static async configurePageTestingModule(
     components: any[],
-    otherParams: any
+    otherParams?: any
   ): Promise<{ fixture: any; instance: any; testBed: typeof TestBed }> {
     const providers = (otherParams && otherParams.providers) || [];
     await TestBed.configureTestingModule({
@@ -128,6 +131,7 @@ export class TestUtils {
         IonicModule,
         MomentModule,
         ReactiveFormsModule,
+        ProvidersModule,
         TranslateModule.forRoot({
           loader: { provide: TranslateLoader, useClass: TranslateFakeLoader }
         }),


### PR DESCRIPTION
Adds preliminary tests for the AppComponent to aid in hitting the coverage requirement in this PR https://github.com/bitpay/copay/pull/8485.

Also simplifies Page Testing in general by moving all providers into their own module to make it easy to import all providers into tests.